### PR TITLE
fix: Enable historyApiFallback

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -34,9 +34,6 @@ module.exports = (config) => {
     resolve: {
       extensions: [ '.tsx', '.ts', '.js', '.jsx' ],
     },
-    devServer: {
-      contentBase: path.resolve(currDir, 'src'),
-    },
     plugins: [
       new HtmlWebpackPlugin({
         filename: 'index.html',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-react-scripts",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "index.js",
   "author": "Sandro Motyl",
   "license": "MIT",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -31,6 +31,7 @@ const start = () => {
     host,
     contentBase: path.resolve(currDir, 'src'),
     watchContentBase: true,
+    historyApiFallback: true,
     hot: true,
     publicPath: '/',
     clientLogLevel: levelLog,


### PR DESCRIPTION
# Pull Request
<!-- Check all the boxes you did -->

- [x] Updated version in package.json (only maintainers);
- [ ] Updated changelog, if necessary;
- [ ] Created tests for all new features;
- [ ] Updated / created documentation or readme.md for all new changes.

### Currently behavior
<!-- Explain the current behavior and the problem with details -->
- Impossibility to work with react router, because historyApiFallback is not enabled.

### Expected behavior
<!-- Explain the implemented solution with details -->
- Enable `historyApiFallback` on WebpackDevServer init of script `start`
- Permit work with router